### PR TITLE
Include GPG key ID in apt_key invocation

### DIFF
--- a/roles/scout_agent/tasks/main.yml
+++ b/roles/scout_agent/tasks/main.yml
@@ -4,7 +4,7 @@
   when: scout_account_key is not defined 
 
 - name: Install the Ubuntu apt-key
-  apt_key: url=https://archive.scoutapp.com/scout-archive.key
+  apt_key: id=A38683E4 url=https://archive.scoutapp.com/scout-archive.key
   when: ansible_distribution == 'Ubuntu'
 
 - name: Set up the scout apt repository


### PR DESCRIPTION
This speeds up execution of the playbook, because it doesn't have to 
download anything if the key is already installed. (It is also necessary 
to correctly report state according to Ansible docs.)